### PR TITLE
OW Platform upgraded to vertx 3, JDK 8 & Nashorn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin
 target
 \#*#
 *~
+.idea

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 
 defaultTasks 'clean', 'build'
 
-version = '1.0.0-gradle-SNAPSHOT'
+version = 'ow-1.1.0-SNAPSHOT'
 group = 'com.etherfirma' 
 archivesBaseName = 'eftessera'
 description = 'The Tessera Java library'
@@ -20,38 +20,37 @@ configurations {
 }
 
 repositories {
-  mavenLocal ()
-  mavenCentral ()
+    mavenCentral()
 
-  maven { 
-    name "Etherfirma RELEASES"
-    credentials { 
-      username = 'deployer'
-      password = 'squidly'
-    } 
-    url 'http://maven.etherfirma.com:8081/nexus/content/repositories/releases/'
-  }
+    maven {
+        name "OpenWager RELEASES"
+        credentials {
+            username = mavenUser
+            password = mavenPassword
+        }
+        url "http://${mavenHost}/nexus/content/repositories/releases/"
+    }
 
-  maven { 
-    name "Etherfirma SNAPSHOTS"
-    credentials { 
-      username = 'deployer'
-      password = 'squidly'
-    } 
-    url 'http://maven.etherfirma.com:8081/nexus/content/repositories/snapshots/'
-  }
+    maven {
+        name "OpenWager SNAPSHOTS"
+        credentials {
+            username = mavenUser
+            password = mavenPassword
+        }
+        url "http://${mavenHost}/nexus/content/repositories/snapshots/"
+    }
 }
 
-uploadArchives { 
+uploadArchives {
   repositories {
-    mavenDeployer { 
+    mavenDeployer {
       configuration = configurations.deployerJars
 
-      snapshotRepository (url: 'http://maven.etherfirma.com:8081/nexus/content/repositories/snapshots') { 
+      snapshotRepository (url: "http://${mavenHost}/nexus/content/repositories/snapshots") {
         authentication (userName: mavenUser, password: mavenPassword)
       }
- 
-      repository (url: 'http://maven.etherfirma.com:8081/nexus/content/repositories/releases/') { 
+
+      repository (url: "http://${mavenHost}/nexus/content/repositories/releases/") {
         authentication (userName: mavenUser, password: mavenPassword)
       }
     }
@@ -65,8 +64,8 @@ dependencies {
   compile 'javaee:javaee-api:5'
   compile 'org.testng:testng:6.5.2'
   compile 'javax.transaction:jta:1.1'
-  compile 'com.etherfirma:efcore:1.1.0-gradle-SNAPSHOT'
-  compile 'com.etherfirma:eflattice:1.0.0-gradle-SNAPSHOT'
+  compile 'com.etherfirma:efcore:ow-1.1.0'
+  compile 'com.etherfirma:eflattice:ow-1.1.0'
   compile 'commons-fileupload:commons-fileupload:1.2.1'
   compile 'commons-lang:commons-lang:2.4'
   compile 'commons-jexl:commons-jexl:1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ configurations {
 }
 
 repositories {
+  mavenLocal ()
   mavenCentral ()
 
   maven { 
@@ -64,7 +65,7 @@ dependencies {
   compile 'javaee:javaee-api:5'
   compile 'org.testng:testng:6.5.2'
   compile 'javax.transaction:jta:1.1'
-  compile 'com.etherfirma:efcore:1.0.4-gradle-SNAPSHOT'
+  compile 'com.etherfirma:efcore:1.1.0-gradle-SNAPSHOT'
   compile 'com.etherfirma:eflattice:1.0.0-gradle-SNAPSHOT'
   compile 'commons-fileupload:commons-fileupload:1.2.1'
   compile 'commons-lang:commons-lang:2.4'

--- a/build.gradle
+++ b/build.gradle
@@ -88,4 +88,19 @@ task showCredentials << {
    } 
 } 
 
+jar {
+
+  from("src/main/java") {
+
+    include "**/*.tld"
+
+    eachFile { details ->
+      if (details.name.contains('tld')) {
+        details.path = "META-INF/$details.name"
+      }
+    }
+  }
+
+}
+
 // EOF 


### PR DESCRIPTION
### What is the problem / feature ?

This library is part of the OW platform upgrade to:
* vertx 3.x
* JDK 8 / Nashorn

It will be required to build OWP

### How did it get fixed / implemented ?

## Configuration changes

Added mavenLocal() to repositories so we can pickup atifacts installed locally. 

Bumped `com.etherfirma:efcore` artifact from `1.0.4-gradle-SNAPSHOT` to `1.1.0-gradle-SNAPSHOT`

## Code changes

I had to adjust the gradle deploy script to include the TLD resurces. 
These tag library descriptors were forgot to be included when the build tool was change from ant to gradle.

### How can someone test / see it ?

NOTE: This build relies on `efcore`  and `eflattice` so you need to build those first.

Install in local maven repo using:

`gradle clean install`

### Related PR
https://github.com/openwager/efcore/pull/1
https://github.com/openwager/eflattice/pull/1